### PR TITLE
feat: Create offline-first Yjs client library

### DIFF
--- a/build-client.sh
+++ b/build-client.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+echo "--- Changing to packages/client directory ---"
+cd packages/client
+echo "--- Installing dependencies ---"
+npm install
+echo "--- Building library ---"
+npm run build
+echo "--- Build complete ---"

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,124 @@
+# Abracadabra Client
+
+A client-side library for interacting with the Abracadabra collaborative document server.
+
+This library provides an offline-first experience for real-time collaboration using Yjs. It combines `y-indexeddb` for local persistence, `y-webrtc` for peer-to-peer communication, and `@hocuspocus/provider` for client-server synchronization.
+
+## Features
+
+- **Offline-first:** Your data is stored locally in IndexedDB, so your application works even without a network connection.
+- **Real-time Collaboration:** Changes are synced seamlessly between users in real-time.
+- **Hierarchical Documents:** Uses Yjs subdocuments to manage complex document structures.
+- **Provider Agnostic:** Automatically manages multiple Yjs providers.
+- **Server-Driven Index:** Fetches a list of documents from the Abracadabra server's REST API.
+
+## Installation
+
+```bash
+npm install @abracadabra/client yjs
+```
+*(Note: At the time of writing, there were environment issues preventing `npm install` from running in the development environment.)*
+
+## Usage
+
+Here's a basic example of how to use the `AbracadabraClient`:
+
+```typescript
+import { AbracadabraClient } from '@abracadabra/client';
+import * as Y from 'yjs';
+
+// 1. Configure the client
+const client = new AbracadabraClient({
+  serverUrl: 'http://localhost:8787',
+  hocuspocusUrl: 'ws://localhost:8787',
+  roomName: 'my-abracadabra-room',
+  token: 'your-jwt-token', // Required for fetching the index and authentication
+});
+
+// 2. Connect to the providers
+client.connect();
+
+// 3. Fetch the document index from the server
+async function initialize() {
+  try {
+    await client.fetchIndex();
+    console.log('Document index loaded.');
+  } catch (error) {
+    console.error('Failed to load document index:', error);
+  }
+}
+
+initialize();
+
+// 4. Get the document index (a Y.Map) and listen for changes
+const documentIndex = client.getDocumentIndex();
+documentIndex.observeDeep(() => {
+  console.log('Document index changed:', documentIndex.toJSON());
+});
+
+// 5. Load a subdocument
+async function openDocument(name: string) {
+  try {
+    const doc = await client.getDocument(name);
+    console.log(`Successfully loaded subdocument: ${name}`);
+
+    // You can now use the Y.Doc instance
+    const ytext = doc.getText('content');
+    ytext.insert(0, 'Hello, World!');
+
+    console.log(ytext.toString());
+
+  } catch (error) {
+    console.error(`Failed to open document: ${name}`, error);
+  }
+}
+
+// Example of opening a document named 'my-doc'
+openDocument('my-doc');
+
+
+// 6. Clean up when you're done
+// window.addEventListener('beforeunload', () => {
+//   client.destroy();
+// });
+```
+
+## API
+
+### `new AbracadabraClient(config)`
+
+Creates a new client instance.
+
+**Config:**
+- `serverUrl` (string): URL of the Abracadabra REST API server.
+- `hocuspocusUrl` (string): URL of the Hocuspocus WebSocket server.
+- `roomName` (string): A name for the collaboration room.
+- `token` (string, optional): A JWT for authentication.
+
+### `client.connect()`
+
+Connects to the configured providers.
+
+### `client.disconnect()`
+
+Disconnects from the providers.
+
+### `client.destroy()`
+
+Destroys the client, disconnects from providers, and cleans up all data.
+
+### `client.fetchIndex(): Promise<void>`
+
+Fetches the document list from the server and populates the index.
+
+### `client.getDocumentIndex(): Y.Map<any>`
+
+Returns the document index, which is a `Y.Map`.
+
+### `client.getDocument(name: string): Promise<Y.Doc>`
+
+Loads a subdocument. Returns a promise that resolves with the `Y.Doc` instance for the subdocument.
+
+### `client.leaveDocument(name: string)`
+
+Unloads a subdocument from memory.

--- a/packages/client/examples/index.html
+++ b/packages/client/examples/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Abracadabra Client Example</title>
+    <style>
+      body { font-family: sans-serif; margin: 2em; }
+      #app { display: flex; gap: 2em; }
+      #sidebar { width: 200px; }
+      #editor { flex-grow: 1; }
+      textarea { width: 100%; height: 400px; }
+      ul { list-style: none; padding: 0; }
+      li { padding: 5px; cursor: pointer; }
+      li:hover { background-color: #eee; }
+      .active { background-color: #ddd; }
+    </style>
+  </head>
+  <body>
+    <h1>Abracadabra Client Example</h1>
+    <div id="app">
+      <div id="sidebar">
+        <h2>Documents</h2>
+        <button id="fetch-index">Fetch Index</button>
+        <ul id="doc-list"></ul>
+      </div>
+      <div id="editor">
+        <h2 id="current-doc-title">Select a document</h2>
+        <textarea id="doc-content" disabled></textarea>
+      </div>
+    </div>
+    <script type="module" src="/main.ts"></script>
+  </body>
+</html>

--- a/packages/client/examples/main.ts
+++ b/packages/client/examples/main.ts
@@ -1,0 +1,125 @@
+import * as Y from 'yjs';
+import { AbracadabraClient } from '../src/index';
+
+const MOCK_TOKEN = 'this-is-a-mock-jwt-token';
+const ROOM_NAME = 'abracadabra-example-room';
+
+// --- UI Elements ---
+const fetchIndexBtn = document.getElementById('fetch-index') as HTMLButtonElement;
+const docList = document.getElementById('doc-list') as HTMLUListElement;
+const currentDocTitle = document.getElementById('current-doc-title') as HTMLHeadingElement;
+const docContent = document.getElementById('doc-content') as HTMLTextAreaElement;
+
+// --- Abracadabra Client Setup ---
+const client = new AbracadabraClient({
+  serverUrl: 'http://localhost:8787',
+  hocuspocusUrl: 'ws://localhost:8787',
+  roomName: ROOM_NAME,
+  token: MOCK_TOKEN,
+});
+
+client.connect();
+
+// --- State ---
+let activeDocName: string | null = null;
+let ytext: Y.Text | null = null;
+
+// --- Functions ---
+
+/**
+ * Renders the document list from the client's index.
+ */
+function renderDocumentList() {
+  docList.innerHTML = '';
+  const documentIndex = client.getDocumentIndex();
+
+  documentIndex.forEach((doc, name) => {
+    const li = document.createElement('li');
+    li.textContent = doc.title || name;
+    li.dataset.docName = name;
+    if (name === activeDocName) {
+      li.classList.add('active');
+    }
+    docList.appendChild(li);
+  });
+}
+
+/**
+ * Loads a document and binds it to the textarea.
+ * @param name The name of the document to load.
+ */
+async function loadDocument(name: string) {
+  if (activeDocName) {
+    client.leaveDocument(activeDocName);
+  }
+
+  activeDocName = name;
+  currentDocTitle.textContent = `Editing: ${name}`;
+  docContent.disabled = false;
+  docContent.value = '';
+
+  try {
+    const subdoc = await client.getDocument(name);
+    ytext = subdoc.getText('content');
+
+    // Bind Y.Text to the textarea
+    ytext.observe(() => {
+      docContent.value = ytext!.toString();
+    });
+
+    docContent.oninput = () => {
+      // This is a simple implementation. For a real editor,
+      // you would calculate the diff and apply it.
+      subdoc.transact(() => {
+        if(ytext) {
+            ytext.delete(0, ytext.length);
+            ytext.insert(0, docContent.value);
+        }
+      });
+    };
+
+    docContent.value = ytext.toString();
+
+  } catch (error) {
+    console.error(`Failed to load document: ${name}`, error);
+    alert(`Failed to load document: ${name}`);
+  }
+
+  renderDocumentList();
+}
+
+// --- Event Listeners ---
+
+fetchIndexBtn.addEventListener('click', async () => {
+  try {
+    await client.fetchIndex();
+    alert('Document index fetched successfully!');
+  } catch (error) {
+    console.error('Failed to fetch index:', error);
+    alert('Failed to fetch index. Make sure the server is running and check the console.');
+  }
+});
+
+docList.addEventListener('click', (event) => {
+  const target = event.target as HTMLLIElement;
+  if (target.tagName === 'LI' && target.dataset.docName) {
+    loadDocument(target.dataset.docName);
+  }
+});
+
+// --- Initial Setup ---
+
+// Observe the document index for changes and re-render the list
+client.getDocumentIndex().observeDeep(() => {
+  renderDocumentList();
+});
+
+// Clean up on page leave
+window.addEventListener('beforeunload', () => {
+  client.destroy();
+});
+
+console.log('Abracadabra Client Example initialized.');
+console.log('1. Make sure the Abracadabra server is running.');
+console.log('2. Click "Fetch Index" to get the list of documents.');
+console.log('3. Click on a document to start editing.');

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@abracadabra/client",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "dev:lib": "tsup src/index.ts --format cjs,esm --dts --watch",
+    "check": "tsc --noEmit",
+    "dev": "vite"
+  },
+  "dependencies": {
+    "y-indexeddb": "^10.3.1",
+    "y-webrtc": "^11.0.1",
+    "@hocuspocus/provider": "^2.15.2",
+    "yjs": "^13.6.23"
+  },
+  "devDependencies": {
+    "tsup": "^8.2.3",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.0"
+  }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,0 +1,199 @@
+import * as Y from 'yjs';
+import { IndexeddbPersistence } from 'y-indexeddb';
+import { WebrtcProvider } from 'y-webrtc';
+import { HocuspocusProvider } from '@hocuspocus/provider';
+
+/**
+ * Configuration options for the AbracadabraClient.
+ */
+export interface AbracadabraClientConfig {
+  /**
+   * The URL of the Hocuspocus WebSocket server.
+   * e.g. 'ws://localhost:8787'
+   */
+  hocuspocusUrl: string;
+
+  /**
+   * The URL of the Abracadabra REST API server.
+   * e.g. 'http://localhost:8787'
+   */
+  serverUrl: string;
+
+  /**
+   * The name of the room or document. This is used for all providers.
+   */
+  roomName: string;
+
+  /**
+   * A JWT token for authentication.
+   */
+  token?: string;
+}
+
+/**
+ * The main client for interacting with the Abracadabra server.
+ */
+export class AbracadabraClient {
+  public doc: Y.Doc;
+  private config: AbracadabraClientConfig;
+
+  private indexeddb: IndexeddbPersistence;
+  private webrtc: WebrtcProvider | null = null;
+  private hocuspocus: HocuspocusProvider;
+
+  private subdocs = new Map<string, Y.Doc>();
+  private documents: Y.Map<Y.Doc>;
+  private documentIndex: Y.Map<any>;
+
+  constructor(config: AbracadabraClientConfig) {
+    this.config = config;
+    this.doc = new Y.Doc();
+    this.documents = this.doc.getMap('documents');
+    this.documentIndex = this.doc.getMap('documentIndex');
+
+    // Set up the providers
+    this.indexeddb = new IndexeddbPersistence(this.config.roomName, this.doc);
+
+    // Hocuspocus provider for client-server sync
+    this.hocuspocus = new HocuspocusProvider({
+      url: this.config.hocuspocusUrl,
+      name: this.config.roomName,
+      document: this.doc,
+      token: this.config.token,
+    });
+
+    // WebRTC provider for peer-to-peer sync
+    // Only initialize in browser environments
+    if (typeof window !== 'undefined') {
+      this.webrtc = new WebrtcProvider(this.config.roomName, this.doc);
+    }
+  }
+
+  /**
+   * Connects to the providers.
+   * Note: The providers connect automatically on instantiation.
+   * This method is for explicitly managing connection status if needed in the future.
+   */
+  public connect() {
+    this.hocuspocus.connect();
+    this.webrtc?.connect();
+  }
+
+  /**
+   * Disconnects from all providers.
+   */
+  public disconnect() {
+    this.hocuspocus.disconnect();
+    this.webrtc?.disconnect();
+    this.indexeddb.destroy();
+  }
+
+  /**
+   * Destroys the client and all associated providers and data.
+   */
+  public destroy() {
+    this.disconnect();
+    this.subdocs.forEach((doc) => doc.destroy());
+    this.doc.destroy();
+  }
+
+  /**
+   * Gets a Y.Doc for a subdocument.
+   *
+   * @param name The name of the subdocument.
+   * @returns A promise that resolves with the Y.Doc for the subdocument.
+   */
+  public async getDocument(name: string): Promise<Y.Doc> {
+    const cachedDoc = this.subdocs.get(name);
+    if (cachedDoc) {
+      return cachedDoc;
+    }
+
+    let subdoc = this.documents.get(name);
+    if (!subdoc) {
+      subdoc = new Y.Doc({ guid: name });
+      this.documents.set(name, subdoc);
+    }
+
+    // Load the subdocument. The Hocuspocus provider will fetch the data.
+    subdoc.load();
+    this.hocuspocus.fetchSubdocument(subdoc);
+
+    // Wait for the subdocument to be synced
+    await new Promise<void>((resolve) => {
+      const onSynced = (data: { document: Y.Doc }) => {
+        if (data.document === subdoc) {
+          this.hocuspocus.off('synced', onSynced);
+          resolve();
+        }
+      };
+      this.hocuspocus.on('synced', onSynced);
+    });
+
+    this.subdocs.set(name, subdoc);
+    return subdoc;
+  }
+
+  /**
+   * Leaves a subdocument, destroying its Y.Doc and removing it from the cache.
+   *
+   * @param name The name of the subdocument to leave.
+   */
+  public leaveDocument(name:string) {
+    const subdoc = this.subdocs.get(name);
+    if (subdoc) {
+      subdoc.destroy();
+      this.subdocs.delete(name);
+    }
+  }
+
+  /**
+   * Fetches the list of documents from the server and populates the document index.
+   */
+  public async fetchIndex() {
+    if (!this.config.token) {
+      throw new Error('Authentication token is required to fetch the document index.');
+    }
+
+    const url = `${this.config.serverUrl}/api/documents/`;
+    const headers: HeadersInit = {
+      'Authorization': `Bearer ${this.config.token}`,
+    };
+
+    try {
+      const response = await fetch(url, { headers });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch document index: ${response.statusText}`);
+      }
+
+      const result = await response.json();
+      const documents = result.data.documents;
+
+      if (!Array.isArray(documents)) {
+        throw new Error('Invalid response format from server.');
+      }
+
+      // Using a transaction to batch updates to the Y.Map
+      this.doc.transact(() => {
+        documents.forEach((doc: any) => {
+          if (doc.path) {
+            this.documentIndex.set(doc.path, doc);
+          }
+        });
+      });
+
+    } catch (error) {
+      console.error('Error fetching document index:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Returns the document index as a Y.Map.
+   * The map is a collaborative data structure and can be observed for changes.
+   * @returns The Y.Map instance representing the document index.
+   */
+  public getDocumentIndex(): Y.Map<any> {
+    return this.documentIndex;
+  }
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: 'examples',
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'examples/index.html'),
+      },
+    },
+  },
+});


### PR DESCRIPTION
This commit introduces a new client-side library for interacting with the Abracadabra collaborative document server.

The new library is located in `packages/client` and provides an offline-first experience for real-time collaboration using Yjs.

Key features:
- A central `AbracadabraClient` class that manages the Yjs document and providers.
- Integration of `y-indexeddb`, `y-webrtc`, and `@hocuspocus/provider` for robust synchronization.
- Support for hierarchical documents using Yjs subdocuments, with methods to load and manage them.
- A mechanism to fetch a document index from the server's REST API.
- An example application in `packages/client/examples` to demonstrate usage.
- A `README.md` with documentation for the client library.

Note: I had to skip the build and test steps, as I was unable to run `npm install`.